### PR TITLE
Fix 404 on project and cache issues

### DIFF
--- a/contrib/inventory/gce_googleapiclient.py
+++ b/contrib/inventory/gce_googleapiclient.py
@@ -531,8 +531,6 @@ def get_cached_data(cache_dir, project=None, zone=None):
 
 
 def store_cache(data, cache_dir, project=None, zone=None):
-    if not os.path.exists(cache_dir):
-        os.makedirs(cache_dir)
     data_dir = cache_dir
     data_file = os.path.join(data_dir, 'projects.json')
 
@@ -545,7 +543,7 @@ def store_cache(data, cache_dir, project=None, zone=None):
             data_file = os.path.join(data_dir, 'instances.json')
 
     if not os.path.exists(data_dir):
-        os.mkdir(data_dir)
+        os.makedirs(data_dir)
 
     log.info("storing cache '%s'", data_file)
 

--- a/contrib/inventory/gce_googleapiclient.py
+++ b/contrib/inventory/gce_googleapiclient.py
@@ -217,6 +217,17 @@ def signal_handler():  # pragma: no cover
     Random.atfork()
 
 
+def is_project_active(project_billing_info):
+    """ Check if the project is billable and active """
+    if not project_billing_info['billingEnabled']:
+        return False
+
+    service = GCAPI.get_service('cloudresourcemanager')
+    request = service.projects().get(projectId=project_billing_info['projectId'])
+    response = request.execute()
+    return response['lifecycleState'] == 'ACTIVE'
+
+
 def get_all_billing_projects(billing_account_name, cache_dir, refresh_cache=True):
     project_ids = []
 
@@ -234,7 +245,7 @@ def get_all_billing_projects(billing_account_name, cache_dir, refresh_cache=True
                                                                      previous_response=response)
 
             for project_billing_info in response['projectBillingInfo']:
-                if project_billing_info['billingEnabled']:
+                if is_project_active(project_billing_info):
                     project_ids.append(project_billing_info['projectId'])
 
         store_cache(data=project_ids, cache_dir=cache_dir)


### PR DESCRIPTION
### Fix ghost 404 project issue

Even if a project has been shut down, it will still be returned by the billing API for 30 days. The issue is that the project won't be returned by the compute API and produce a 404 when the zones are retrieved. So we should check if the project is active before adding it to the list.

### Fix OSError on mkdir cache when the zones are manually set

When the zones are manually configured via the command line or the config file, the script fails:

```
Traceback (most recent call last):
  File "./gce_googleapiclient.py", line 625, in <module>
    main(ARGS)
  File "./gce_googleapiclient.py", line 606, in main
    project_zone_list).get(timeout):
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 572, in get
    raise self._value
OSError: [Errno 2] No such file or directory: '.gce_cache/kube-test-eu-43-proj-xxxxxxx/europe-west1-b'
```

The list of zone per project is not cached in the `.gce_cache/project_name/zones.json` file if the zone is given to the script. So when the dir for the zone is created [here](https://github.com/KohlsTechnology/ansible/blob/29a545aa7c95274a2f348480278f143cfa72842c/contrib/inventory/gce_googleapiclient.py#L537) it fails on `.gce_cache/project_name/zone_name`, because the folder `.gce_cache/project_name` doesn't exist.

Let's do a `mkdir -p` to ensure the directory is created in any case.