### PR TITLE
Fix cache '~' path issue

### DIFF
--- a/contrib/inventory/gce_googleapiclient.py
+++ b/contrib/inventory/gce_googleapiclient.py
@@ -563,6 +563,9 @@ def main(args):
     cache_dir = args['--cache-dir']
     refresh_cache = bool(args['--refresh-cache'])
 
+    # The cache configuration directory might content the '~' home directory
+    cache_dir = os.path.expanduser(cache_dir)
+
     if not project_list and not billing_account_name:
         print("ERROR: You didn't specified any project (parameter: --project) which means you want"
               "all projects. However, to get the list of all projects, we need the billing account"


### PR DESCRIPTION
By default, Python doesn't translate the '~' as the $HOME directory. We should use os.path.expanduser function to avoid this situation:

```bash
$ pwd
/home/erouan/Documents/ansible
$ contrib/inventory/gce_googleapiclient.py --cache-dir '~/.gce_cache' > /dev/null
$ ls -hla
total 484K
drwxrwxr-x.  3 erouan erouan 4.0K Mar 14 14:56 '~' # <----- Wrong place
drwxrwxr-x. 17 erouan erouan 4.0K Mar 14 14:56  .
drwxr-xr-x. 22 erouan erouan 4.0K Mar  8 16:40  ..
-rw-rw-r--.  1 erouan erouan  77K Jul 20  2017  ansible-core-sitemap.xml
-rw-rw-r--.  1 erouan erouan  317 Feb 16 13:49  ansible.iml
...
```